### PR TITLE
Add retry field to SSEMessage interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ interface SSEMessage {
   id?: string;
   event?: string;
   data?: null | boolean | number | bigint | string | Jsonifiable;
+  retry?: number;
 }
 ```
 
 `data` is optional and can be any primitive type (except `Symbol`) or an object, in which case it will be converted to JSON. More information about `Jsonifiable` can be found [here](https://github.com/sindresorhus/type-fest/blob/main/source/jsonifiable.d.ts). If data is omitted or set to `undefined` or `null`, the empty `data` field will be added. 
 
+`retry` is an optional field that specifies the reconnection time in milliseconds. Must be a non-negative integer.  Invalid values result in the field being ignored.
 
 ### Handling Errors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudflare-workers-sse",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudflare-workers-sse",
-      "version": "2.0.0-alpha.2",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "type-fest": "^4.33.0"

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -12,6 +12,7 @@ export interface SSEMessage {
   id?: string;
   event?: string;
   data?: null | boolean | number | bigint | string | Jsonifiable;
+  retry?: number;
 }
 
 export interface SSEOptions<Env> {
@@ -114,6 +115,7 @@ function serializeMessage(message: SSEMessage) {
     serialized += `event: ${message.event}\n`;
   }
 
+  // Data field is always present
   if (message.data === null || message.data === undefined) {
     serialized += "data:";
   } else {
@@ -126,6 +128,17 @@ function serializeMessage(message: SSEMessage) {
       .split("\n")
       .map((line) => `data: ${line}`)
       .join("\n");
+  }
+
+  if (message.retry !== undefined) {
+    // Only include retry if it's a positive integer
+    if (
+      typeof message.retry === "number" &&
+      Number.isInteger(message.retry) &&
+      message.retry > 0
+    ) {
+      serialized += `\nretry: ${message.retry}`;
+    }
   }
 
   serialized += "\n\n";

--- a/test/sse.spec.ts
+++ b/test/sse.spec.ts
@@ -101,6 +101,10 @@ describe("sse", () => {
       };
 
       yield { data: ["Alice", "Bob"] };
+
+      // with retry field
+      yield { retry: 1000 };
+      yield { retry: 2000, data: "with retry" };
     });
 
     const response = await fetchHandler(
@@ -150,9 +154,138 @@ data: {"from":"Alice","to":"Bob"}
 
 data: ["Alice","Bob"]
 
+data:
+retry: 1000
+
+data: with retry
+retry: 2000
+
 `;
 
     expect(messages.join("")).toBe(expectedOutput);
+  });
+
+  describe("retry field validation", () => {
+    it("includes valid retry value", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield { retry: 1000 };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe("data:\nretry: 1000\n\n");
+    });
+
+    it("ignores negative retry value", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield { retry: -1000 };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe("data:\n\n");
+    });
+
+    it("ignores non-integer retry value", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield { retry: 1000.5 };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe("data:\n\n");
+    });
+
+    it("ignores zero retry value", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield { retry: 0 };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe("data:\n\n");
+    });
+
+    it("handles retry with other fields", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield {
+          retry: 1000,
+          id: "test-id",
+          event: "test-event",
+          data: "test data"
+        };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe(
+        "id: test-id\nevent: test-event\ndata: test data\nretry: 1000\n\n"
+      );
+    });
+
+    it("handles multiple retry values in sequence", async () => {
+      const ctx = createExecutionContext();
+      const fetchHandler = sse(async function* () {
+        yield { retry: 1000 };
+        yield { retry: 2000 };
+        yield { retry: -1000 }; // Should be ignored
+        yield { retry: 3000 };
+      });
+
+      const response = await fetchHandler(
+        new Request("http://test.sse.workers.dev"),
+        env,
+        ctx
+      );
+
+      const messages = await readResponseStream(response);
+      await waitOnExecutionContext(ctx);
+
+      expect(messages[0]).toBe("data:\nretry: 1000\n\n");
+      expect(messages[1]).toBe("data:\nretry: 2000\n\n");
+      expect(messages[2]).toBe("data:\n\n");
+      expect(messages[3]).toBe("data:\nretry: 3000\n\n");
+    });
   });
 
   it("calls onError when handler throws", async () => {


### PR DESCRIPTION
This commit introduces a new optional `retry` field in the `SSEMessage` interface, which specifies the reconnection time in milliseconds. The serialization function has been modified to include the `retry` field only if it is a positive integer. Additionally, tests have been added to validate the behavior of the `retry` field, ensuring that invalid values are ignored and that it can coexist with other fields in the message.